### PR TITLE
add detail to error message to help user

### DIFF
--- a/stats/stats.go
+++ b/stats/stats.go
@@ -64,11 +64,11 @@ func ReadJson(file string) StatsJSON {
 	var statsJSON StatsJSON
 	data, err := ioutil.ReadFile(file)
 	if err != nil {
-		log.Fatal("Could not read json file", err)
+		log.Fatalf("Could not read json file (%v).  Error: %v", file, err)
 	}
 	err = json.Unmarshal(data, &statsJSON)
 	if err != nil {
-		log.Fatal("Could not parse json file", err)
+		log.Fatalf("Could not parse json file (%v).  Error: %v", file, err)
 	}
 
 	return statsJSON


### PR DESCRIPTION
Adds detail to some of the error messages.  Better to get a specific error message to help with debugging users' errors, rather than "it doesn't work".

I did this while looking at what happened if I gave the app an empty and/or corrupt JSON file.  I expect this to be the case if we end up with Switch captains (such as myself) getting files emailed to them for entry.  Lots of opportunity for bad things to happen to the files.